### PR TITLE
minor update to the .card-img class

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -176,6 +176,8 @@
 .card-img {
   // margin: -1.325rem;
   @include border-radius($card-border-radius-inner);
+  width: 100%;
+  height: auto;
 }
 .card-img-overlay {
   position: absolute;


### PR DESCRIPTION
when testing this on my own the image don't take the full width but also has some extra space (padding on the .card itself that could be removed to make the card better). Your site documented it the way it should look like but the CSS doesn't work towards that.